### PR TITLE
Initial setup of the TailwindCSS hugo module

### DIFF
--- a/tailwindcss/config/_default/module.toml
+++ b/tailwindcss/config/_default/module.toml
@@ -1,6 +1,6 @@
 [hugoVersion]
 extended = true
-min = "0.75.0"
+min = "0.84.0"
 
 [[mounts]]
 source = "assets"

--- a/tailwindcss/config/_default/module.toml
+++ b/tailwindcss/config/_default/module.toml
@@ -1,0 +1,7 @@
+[hugoVersion]
+extended = true
+min = "0.70.0"
+
+[[mounts]]
+source = "assets"
+target = "assets"

--- a/tailwindcss/config/_default/module.toml
+++ b/tailwindcss/config/_default/module.toml
@@ -1,6 +1,6 @@
 [hugoVersion]
 extended = true
-min = "0.70.0"
+min = "0.75.0"
 
 [[mounts]]
 source = "assets"

--- a/tailwindcss/config/_default/params.toml
+++ b/tailwindcss/config/_default/params.toml
@@ -1,0 +1,1 @@
+_merge = "none"

--- a/tailwindcss/package.hugo.json
+++ b/tailwindcss/package.hugo.json
@@ -18,9 +18,7 @@
     "@dnb-org/commitlint-config": "3.3.3",
     "@dnb-org/standard-version-config": "3.3.0",
     "autoprefixer": "10.3.7",
-    "copyfiles": "^2.4.1",
-    "postcss": "8.3.11",
-    "rimraf": "^3.0.2"
+    "postcss": "8.3.11"
   },
   "homepage": "https://github.com/dnb-org/libraries/tree/master/tailwindcss",
   "license": "MIT",

--- a/tailwindcss/package.hugo.json
+++ b/tailwindcss/package.hugo.json
@@ -11,19 +11,20 @@
       "@dnb-org/commitlint-config"
     ]
   },
+  "dependencies": {
+    "tailwindcss": "2.2.19"
+  },
   "devDependencies": {
     "@dnb-org/commitlint-config": "3.3.3",
     "@dnb-org/standard-version-config": "3.3.0",
     "autoprefixer": "10.3.7",
     "copyfiles": "^2.4.1",
     "postcss": "8.3.11",
-    "rimraf": "^3.0.2",
-    "tailwindcss": "2.2.19"
+    "rimraf": "^3.0.2"
   },
   "homepage": "https://github.com/dnb-org/libraries/tree/master/tailwindcss",
   "license": "MIT",
   "scripts": {
-    "build": "rimraf ./assets/tailwindcss/* && copyfiles -V -u 2 -a node_modules/tailwindcss/* ./assets/tailwindcss",
     "release": "standard-version --release-as patch -a -t \"tailwindcss/v\" --releaseCommitMessageFormat \"chore(release): tailwindcss/v{{currentTag}}\" && ./bin/release-hook-postrelease.sh",
     "release:major": "standard-version --release-as major -a -t \"tailwindcss/v\" --releaseCommitMessageFormat \"chore(release): tailwindcss/v{{currentTag}}\" && ./bin/release-hook-postrelease.sh",
     "release:next": "standard-version --release-as minor -a -t \"tailwindcss/v\" --releaseCommitMessageFormat \"chore(release): tailwindcss/v{{currentTag}}\" && ./bin/release-hook-postrelease.sh"

--- a/tailwindcss/package.json
+++ b/tailwindcss/package.json
@@ -1,0 +1,1 @@
+package.hugo.json

--- a/tailwindcss/package.json
+++ b/tailwindcss/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@dnb-org-libraries/tailwindcss",
+  "description": "Tailwind CSS as a Hugo module",
+  "version": "0.0.1",
+  "author": "Ringo De Smet <ringo@de-smet.name>",
+  "bugs": {
+    "url": "https://github.com/dnb-org/libraries/issues"
+  },
+  "commitlint": {
+    "extends": [
+      "@dnb-org/commitlint-config"
+    ]
+  },
+  "devDependencies": {
+    "@dnb-org/commitlint-config": "3.3.3",
+    "@dnb-org/standard-version-config": "3.3.0",
+    "autoprefixer": "10.3.7",
+    "copyfiles": "^2.4.1",
+    "postcss": "8.3.11",
+    "rimraf": "^3.0.2",
+    "tailwindcss": "2.2.19"
+  },
+  "homepage": "https://github.com/dnb-org/libraries/tree/master/tailwindcss",
+  "license": "MIT",
+  "scripts": {
+    "build": "rimraf ./assets/tailwindcss/* && copyfiles -V -u 2 -a node_modules/tailwindcss/* ./assets/tailwindcss",
+    "release": "standard-version --release-as patch -a -t \"tailwindcss/v\" --releaseCommitMessageFormat \"chore(release): tailwindcss/v{{currentTag}}\" && ./bin/release-hook-postrelease.sh",
+    "release:major": "standard-version --release-as major -a -t \"tailwindcss/v\" --releaseCommitMessageFormat \"chore(release): tailwindcss/v{{currentTag}}\" && ./bin/release-hook-postrelease.sh",
+    "release:next": "standard-version --release-as minor -a -t \"tailwindcss/v\" --releaseCommitMessageFormat \"chore(release): tailwindcss/v{{currentTag}}\" && ./bin/release-hook-postrelease.sh"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dnb-org/libraries.git"
+  },
+  "keywords": [
+    "hugo",
+    "tailwindcss"
+  ]
+}


### PR DESCRIPTION
Hello @davidsneighbour,

I started this draft pull request for 2 purposes:

1. are you interested in accepting TailwindCSS as an additional styling library next to Bootstrap.
2. as a base to discuss the questions I have

Hoping that you are positive on 1, I need to know how everything needs to fit in your release procedure driven by your configuration libraries.

Contrary to the setup of your `bootstrap5` module, I can't use the upstream TailwindCSS git repo as a dependency in this module. I need the built version of TailwindCSS coming from the npm package. I added `tailwindcss` as a dependency in my `package.json` and added a `build` script which shows the intent: it copies the content from `./node_modules/tailwindcss` to `assets/tailwindcss`. After that, I still need to commit the content in `assets/tailwindcss` before releasing the module. The content of the assets folder needs to be updated with the contents of the corresponding npm package.

How should I integrate the following steps into the release proces:

```
$ rm -rf ./assets/tailwindcss
$ cp `./node_modules/tailwindcss` to `./assets/tailwindcss`
$ git add .
$ git commit -m "<appropriate commit message here>"
```

Hoping for a positive message. 😉 

Signed-off-by: Ringo De Smet <ringo@de-smet.name>