### PR TITLE
Initializing this library as a Hugo module

### DIFF
--- a/tailwindcss/go.mod
+++ b/tailwindcss/go.mod
@@ -1,0 +1,3 @@
+module github.com/dnb-org/libraries/tailwindcss
+
+go 1.16


### PR DESCRIPTION
I forgot to initialize the TailwindCSS library as a Hugo module.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>